### PR TITLE
Bugfix/SM-92: Exporting empty ablation

### DIFF
--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -258,7 +258,9 @@ def export_openep_mat(
             divergence=case.analyse.divergence
         )
 
-    userdata['rf'] = _export_ablation_data(ablation=case.ablation)
+    if case.ablation is not None:
+        userdata['rf'] = _export_ablation_data(ablation=case.ablation)
+
     scipy.io.savemat(
         file_name=filename,
         mdict={'userdata': userdata},


### PR DESCRIPTION
- Don't export ablation if  Ablation == None, 'rf' will not be present in exported openmat file.