### PR TITLE
Feature/SM-168-80: RBF legacy and Fibre lines

### DIFF
--- a/openep/analysis/_conduction_velocity.py
+++ b/openep/analysis/_conduction_velocity.py
@@ -321,6 +321,18 @@ def radial_basis_function(
         leaf_size (int, optional):
             Leaf size parameter for the KDTree used in nearest neighbor queries.
             Defaults to 5.
+
+    Returns:
+        tuple:
+            cv_values (ndarray):
+              Array of conduction velocity values at the bipolar electrogram point locations.
+
+            cv_centroids (ndarray):
+              Array of point coordinates (Nx3) corresponding to the positions of the returned `cv_values`.
+              Default these are the original `bipolar_egm_pts`.
+
+            cv_interpolated (ndarray):
+              Array of conduction velocity values interpolated at all mesh points.
     """
     mesh = case.create_mesh()
 

--- a/openep/analysis/_conduction_velocity.py
+++ b/openep/analysis/_conduction_velocity.py
@@ -301,8 +301,8 @@ def radial_basis_function(
         local_activation_time (array):
             Array of local activation times corresponding to the bipolar electrogram points.
 
-        mesh (Mesh):
-            Mesh object containing point coordinates and methods (e.g., for computing derivatives).
+        case (Case):
+            Case to create Mesh object containing point coordinates and methods (e.g., for computing derivatives).
 
         project_on_surface (bool, optional):
             If True, projects the bipolar electrogram points onto the mesh surface before interpolation.
@@ -348,14 +348,19 @@ def radial_basis_function(
     gradients = deriv['gradient']
 
     grad_norm_sq = gradients[:, 0] ** 2 + gradients[:, 1] ** 2 + gradients[:, 2] ** 2
-    cv = 1 / np.sqrt(grad_norm_sq)
+    # CV at mesh points (already interpolated)
+    cv_interpolated = 1 / np.sqrt(grad_norm_sq)
 
     tree = KDTree(mesh.points, leaf_size=leaf_size)
     _, indices = tree.query(bipolar_egm_pts, k=1)
-    cv_centroids = mesh.points[indices.flatten()]
-    cv_values = cv[indices.flatten()]
 
-    return cv_values, cv_centroids
+    # We are using the cv_centroids at the bi_egm location
+    # rather than the ones moved closer to the mesh
+    # cv_centroids = mesh.points[indices.flatten()]
+    cv_centroids = bipolar_egm_pts
+    cv_values = cv_interpolated[indices.flatten()]
+
+    return cv_values, cv_centroids, cv_interpolated
 
 
 def divergence(

--- a/openep/analysis/_conduction_velocity.py
+++ b/openep/analysis/_conduction_velocity.py
@@ -424,10 +424,14 @@ def divergence(
     basic_mesh = pv.PolyData(temp_mesh.points, temp_mesh.faces)
     interpolation_kws = dict() if interpolation_kws is None else interpolation_kws
 
+    tree = KDTree(temp_mesh.points, leaf_size=2)
+    dist, ind = tree.query(bipolar_egm_pts, k=1)
+    closest_mesh_points_to_egm_points = temp_mesh.points[ind.flat]
+
     interpolated_scalar = interpolate_general_cloud_points_onto_surface(
         case=case,
         cloud_values=local_activation_time,
-        cloud_points=bipolar_egm_pts,
+        cloud_points=closest_mesh_points_to_egm_points,
         **interpolation_kws
     )
 

--- a/openep/analysis/analyse.py
+++ b/openep/analysis/analyse.py
@@ -18,6 +18,7 @@
 
 """Module containing analysis classes"""
 from ._conduction_velocity import *
+from .vector_field_tracer import VectorFieldTracer
 from ..case.case_routines import interpolate_general_cloud_points_onto_surface
 
 
@@ -36,8 +37,9 @@ class Analyse:
 
     """
     def __init__(self, case):
-        self.conduction_velocity = ConductionVelocity(case)
-        self.divergence = Divergence(case)
+        self.conduction_velocity: ConductionVelocity = ConductionVelocity(case)
+        self.divergence: Divergence = Divergence(case)
+        self.vector_field_tracer: VectorFieldTracer = VectorFieldTracer()
 
 
 class ConductionVelocity:

--- a/openep/analysis/analyse.py
+++ b/openep/analysis/analyse.py
@@ -131,7 +131,15 @@ class ConductionVelocity:
                - self._case.electric.annotations.reference_activation_time[include])
 
         cv_method = supported_cv_methods[method]
-        self.values, self.centers = cv_method(bipolar_egm_pts, lat, self._case, **method_kwargs)
+        if method == 'rbf':
+            ignore_interpolation = method_kwargs.pop('ignore_interpolation', False)
+            self.values, self.centers, field = cv_method(bipolar_egm_pts, lat, self._case, **method_kwargs)
+            if ignore_interpolation:
+                self._case.fields.conduction_velocity = field
+                apply_scalar_field = False
+
+        else:
+            self.values, self.centers = cv_method(bipolar_egm_pts, lat, self._case, **method_kwargs)
 
         if apply_scalar_field:
             self._case.fields.conduction_velocity = interpolate_general_cloud_points_onto_surface(

--- a/openep/analysis/vector_field_tracer.py
+++ b/openep/analysis/vector_field_tracer.py
@@ -1,0 +1,155 @@
+# OpenEP
+# Copyright (c) 2021 OpenEP Collaborators
+#
+# This file is part of OpenEP.
+#
+# OpenEP is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenEP is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program (LICENSE.txt).  If not, see <http://www.gnu.org/licenses/>
+
+from evenlyspacedstreamlines import evenly_spaced_streamlines
+import pyvista as pv
+import numpy as np
+
+
+__all__ = ['VectorFieldTracer']
+
+class VectorFieldTracer:
+    """
+    Calculate line/streamline visualisation of vector data for each cell data
+    """
+    @staticmethod
+    def calculate_streamlines(
+            mesh,
+            direction,
+            radius,
+            **kwargs,
+    ):
+        """
+        Uses V. Jacquemet's method to create evenly-spaced streamlines
+
+        Arguments:
+            mesh (pv.Polydata): Case object's mesh
+            direction (np.ndarray) array of shape N_cells x 3 e.g. fibre vectors
+            radius (float): the distance between streamlines will be larger than
+                the radius and smaller than 2*radius
+
+        Optional keyword-only args:
+            seed_points (int): number of seed points tested to generate each
+                streamline; the longest streamline is kept (default: 32)
+            seed_region (int array): list of triangle indices among which seed
+                points are picked (default: None, which means that all triangles
+                are considered)
+            orthogonal (bool): if True, rotate the orientation by 90 degrees
+                (default: False)
+            oriented_streamlines (bool): if True, streamlines only follow the
+                vector field in the direction it points to (and not the opposite
+                direction); the outputted streamlines are then oriented according
+                to the vector field.
+                If False (default), the orientation field is defined modulo pi
+                instead of 2pi
+            allow_tweaking_orientation (bool): if an orientation vector is parallel
+                to an edge of the triangle, a small random perturbation is applied
+                to that vector to satisfy the requirement (default: True);
+                otherwise an exception is raised when the requirement is not
+                satisfied
+            singularity_mask_radius (float): when the orientation field has a
+                singularity (e.g. focus or node), prevent streamlines from entering
+                a sphere of radius 'singularity_mask_radius' x 'radius' around
+                that singularity (default: 0.1)
+            max_length (int): maximal number of iterations when tracing
+                streamlines; it is needed because of nearly-periodic streamlines
+                (default: 0, which means equal to the number of triangles)
+            max_angle (float): stop streamline integration if the angle between
+                two consecutive segments is larger than max_angle in degrees;
+                0 means straight line and 180 means U-turn (default: 90)
+            avoid_u_turns (bool): restrict high curvatures by maintaining a
+                lateral (perpendicular) distance of at least 'radius' between
+                a segment of the streamline and the other segments of the same
+                streamline; this automatically sets 'max_angle' to at most
+                90 degrees (default: True)
+            random_seed (int): initialize the seed for pseudo-random number
+                generation (default: seed based on clock)
+            parallel (bool): if True (default), use multithreading wherever
+                implemented
+            num_threads (int): if possible, use that number of threads for parallel
+                computing (default: let OpenMP choose)
+
+            Returns:
+        np.ndarray: Array of shape (N_lines*2, 3), containing start and end points of
+        each fibre line segment, suitable for conversion into a PolyData with lines.
+
+        Usage:
+            The returned array can be passed to ``pyvista.Plotter.add_mesh`` to
+            visualise fibre streamlines on the mesh.
+        """
+
+        # Obtain triangles from face
+        faces = mesh.faces.reshape((-1, 4))
+        assert np.all(faces[:, 0] == 3), "Not all faces on the mesh are triangles!"
+        triangles = faces[:, 1:]
+
+        list_of_lines, _, _ = evenly_spaced_streamlines(
+            vertices=mesh.points,
+            triangles=triangles,
+            orientation=direction,
+            radius=radius,
+            **kwargs
+        )
+
+        # Create poly mesh using list_of_lines
+        # This allows much faster load of lines (single add_mesh)
+        cells = []
+        offset = 0
+        points = np.vstack(list_of_lines)
+        for line in list_of_lines:
+            n = len(line)
+            cells.append(np.hstack(([n], np.arange(offset, offset + n))))
+            offset += n
+        poly = pv.PolyData(points)
+        cells = np.hstack(cells).astype(np.int64)
+        poly.lines = cells
+
+        return poly
+
+    @staticmethod
+    def calculate_vector_lines(
+            mesh,
+            direction,
+            mask_threshold
+    ):
+        """
+        Adds fibre lines to each cell on the mesh.
+
+        Arguments:
+            mesh (pv.Polydata): Case object's mesh
+            direction (np.ndarray) array of shape N_cells x 3 e.g. fibre vectors
+            mask_threshold (int): Portion of cells to include the fibre lines on.
+
+        Returns:
+            np.ndarray: Array of shape (N_lines, 2, 3) or flattened (N_lines*2, 3),
+            giving start and end points of each line segment.
+
+        Usage:
+            The returned array can be passed to ``pyvista.Plotter.add_lines`` to
+            visualise fibre directions on the mesh.
+        """
+        cell_centers = mesh.cell_centers()
+
+        # Not drawing lines for all cells (too many!)
+        mask = np.random.rand(cell_centers.n_points) < mask_threshold
+
+        # Calculate the start and end of the fibre line, and add mask.
+        start_of_line = mesh.cell_centers().points[mask]
+        end_of_line = np.add(mesh.cell_centers().points, direction)[mask]
+
+        return np.hstack((start_of_line, end_of_line)).reshape(-1, 3)

--- a/openep/analysis/vector_field_tracer.py
+++ b/openep/analysis/vector_field_tracer.py
@@ -16,10 +16,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program (LICENSE.txt).  If not, see <http://www.gnu.org/licenses/>
 
-from evenlyspacedstreamlines import evenly_spaced_streamlines
 import pyvista as pv
 import numpy as np
-
 
 __all__ = ['VectorFieldTracer']
 
@@ -92,6 +90,7 @@ class VectorFieldTracer:
             The returned array can be passed to ``pyvista.Plotter.add_mesh`` to
             visualise fibre streamlines on the mesh.
         """
+        from evenlyspacedstreamlines import evenly_spaced_streamlines
 
         # Obtain triangles from face
         faces = mesh.faces.reshape((-1, 4))

--- a/openep/case/case_routines.py
+++ b/openep/case/case_routines.py
@@ -417,11 +417,18 @@ class Interpolator:
         else:
             self.method_kws = {}
 
-        self.interpolate = self.method(
-            self.points,
-            self.field,
-            **self.method_kws,
-        )
+        if self.method is scipy.interpolate.Rbf:
+            self.interpolate = self.method(
+                self.points[:,0], self.points[:,1], self.points[:,2],
+                self.field,
+                **self.method_kws,
+            )
+        else:
+            self.interpolate = self.method(
+                self.points,
+                self.field,
+                **self.method_kws,
+            )
 
     def __call__(self, surface_points, max_distance=None):
         """Interpolate the scalar field onto a new set of coordinates
@@ -437,7 +444,14 @@ class Interpolator:
             interpolated_field (ndarray): Scalar field interpolated onto the new points.
         """
 
-        interpolated_field = self.interpolate(surface_points)
+        if self.method is scipy.interpolate.Rbf:
+            interpolated_field = self.interpolate(
+                surface_points[:,0],
+                surface_points[:,1],
+                surface_points[:,2]
+            )
+        else:
+            interpolated_field = self.interpolate(surface_points)
 
         if max_distance is not None:
             within_distance = calculate_points_within_distance(

--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -100,13 +100,11 @@ class Fields:
         """
 
         fields = cls()
+        
+        #Load all fieldds from mesh
         for point_data in mesh.point_data:
-            if point_data not in fields:
-                continue
             fields[point_data] = np.asarray(mesh.point_data[point_data])
         for cell_data in mesh.cell_data:
-            if cell_data not in fields:
-                continue
             fields[cell_data] = np.asarray(mesh.cell_data[cell_data])
 
         return fields

--- a/openep/data_structures/vectors.py
+++ b/openep/data_structures/vectors.py
@@ -3,7 +3,6 @@ import numpy as np
 
 __all__ = []
 
-
 @attrs(auto_attribs=True, auto_detect=True)
 class Vectors:
     """
@@ -18,7 +17,7 @@ class Vectors:
 
     # TODO: move divergence arrows into Arrows class
     # TODO: remove longitudinal and transversal arrows from Fields class
-    fibres: np.ndarray = None
+    _fibres: np.ndarray = None
     divergence: np.ndarray = None
     linear_connections: np.ndarray = None
     linear_connection_regions: np.ndarray = None
@@ -42,6 +41,14 @@ class Vectors:
 
     def __contains__(self, arrow):
         return arrow in self.__dict__.keys()
+
+    @property
+    def fibres(self):
+        return self._fibres
+
+    @fibres.setter
+    def fibres(self, array):
+        self._fibres = None if np.all(array == [1, 0, 0]) else array
 
     @property
     def linear_connection_regions_names(self):
@@ -74,40 +81,34 @@ def extract_vector_data(surface_data, indices):
         vectors (Vectors): Class for storing information about arrows/vectors and lines on surface
     """
     vectors = Vectors()
-    n_fibres = indices.shape[0]
+    n_cells = indices.shape[0]
 
-    # add fibres
-    default_fibres_data = np.tile([1, 0, 0], (n_fibres, 1))
-
-    if not surface_data.get('signalMaps'):
-        vectors.fibres = default_fibres_data
+    # add default fibres
+    vectors.fibres = np.tile([1, 0, 0], (n_cells, 1))
+    signal_props = surface_data.get('signalMaps')
+    if not signal_props:
         return vectors
 
-    signal_props = surface_data.get('signalMaps')
-
+    # retrieve linear_connections indices
     lin_conns = signal_props.get('linear_connections')
-    if lin_conns is not None:
-        if isinstance(lin_conns, dict):
-            vectors.linear_connections = lin_conns.get('value')
-        else:
-            vectors.linear_connections = lin_conns
+    vectors.linear_connections = lin_conns
+    if isinstance(lin_conns, dict):
+        vectors.linear_connections = lin_conns.get('value')
 
+    # retrieve linear_connections region associated
     lin_conns_region = signal_props.get('linear_connection_regions')
-    if lin_conns_region is not None:
-        if isinstance(lin_conns_region, dict):
-            vectors.linear_connection_regions = lin_conns_region.get('value')
-        else:
-            vectors.linear_connection_regions = lin_conns_region
+    vectors.linear_connection_regions = lin_conns_region
+    if isinstance(lin_conns_region, dict):
+        vectors.linear_connection_regions = lin_conns_region.get('value')
 
-        n_fibres += len(vectors.linear_connection_regions)
+    # retrieve fibres
+    _fibres = signal_props.get('fibres')
+    if isinstance(_fibres, dict):
+        _fibres = _fibres.get('value')
 
-    fibres = signal_props.get('fibres')
-    if fibres is not None:
-        if isinstance(fibres, dict):
-            vectors.fibres = fibres.get('value')
-        else:
-            vectors.linear_connection_regions = lin_conns_region
-    else:
-        vectors.fibres = default_fibres_data
+    if _fibres is not None:
+        # Ensure fibres match elem/face data size
+        # Exclude fibre data associated with linear regions
+        vectors.fibres = _fibres[0:n_cells]
 
     return vectors

--- a/openep/io/matlab.py
+++ b/openep/io/matlab.py
@@ -233,6 +233,16 @@ def _load_mat_below_v73(filename):
         simplify_cells=True,
     )['userdata']
 
+    # Ensure data are the right shape
+    data['electric']['names'] = np.atleast_1d(data['electric']['names'])
+    data['electric']['include'] = np.atleast_1d(data['electric']['include'])
+    data['electric']['electrodeNames_bip'] = np.atleast_1d(data['electric']['electrodeNames_bip'])
+    data['electric']['egmX'] = np.atleast_2d(data['electric']['egmX']) if data['electric']['egmX'].size!=0 else np.array([])
+    data['electric']['egm'] = np.atleast_1d(data['electric']['egm'])
+    data['electric']['egmGain'] = np.atleast_1d(data['electric']['egmGain'])
+    data['electric']['egmSurfX'] = np.atleast_2d(data['electric']['egmSurfX']) if data['electric']['egmSurfX'].size!=0 else np.array([])
+    data['electric']['barDirection'] = np.atleast_2d(data['electric']['barDirection']) if data['electric']['barDirection'].size!=0 else np.array([])
+
     data['electric']['tags'] = _decode_tags(data['electric']['tags'])
 
     data['electric']['impedances']['time'] = _cast_to_float(data['electric']['impedances']['time'])

--- a/openep/io/readers.py
+++ b/openep/io/readers.py
@@ -190,19 +190,21 @@ def load_opencarp(
     )
 
     # Fibres data
+    n_cells = indices_data.shape[0]
     if fibres is None:
-        fibres_data = np.tile([1, 0, 0], (len(data)-1, 1))
+        _fibres = np.tile([1, 0, 0], (n_cells, 1))
     else:
         with open(fibres, 'r') as f:
             first_value = f.readline().strip().split()[0]
 
         if first_value == "1":
-            fibres_data = np.loadtxt(fibres, skiprows=1)
+            _fibres = np.loadtxt(fibres, skiprows=1)
         else:
-            fibres_data = np.loadtxt(fibres)
+            _fibres = np.loadtxt(fibres)
+        _fibres = _fibres[0:n_cells]
 
-    arrows = Vectors(
-        fibres=fibres_data,
+    vectors = Vectors(
+        fibres=_fibres,
         linear_connections=linear_connection_data if len(linear_connection_data) > 0 else None,
         linear_connection_regions=linear_connection_regions if len(linear_connection_regions) > 0 else None,
     )
@@ -211,7 +213,7 @@ def load_opencarp(
     ablation = Ablation()
     notes = np.asarray([], dtype=object)
 
-    return Case(name, points_data, indices_data, fields, electric, ablation, notes, arrows)
+    return Case(name, points_data, indices_data, fields, electric, ablation, notes, vectors)
 
 
 def load_vtk(filename, name=None):

--- a/openep/io/writers.py
+++ b/openep/io/writers.py
@@ -146,15 +146,22 @@ def export_openCARP(
             )
 
     # Save fibres
-    if case.vectors.fibres is not None:
-        with open(output_path.with_suffix('.lon'), 'w') as f:
-            f.write("1\n")
-            np.savetxt(
-                f,
-                case.vectors.fibres,
-                fmt="%.6f",
-                comments='',
-            )
+    if case.vectors.fibres is None:
+        _fibres = np.tile([1, 0, 0], (n_lines, 1))
+    else:
+        _dummy_vals_for_lin_connections = np.tile([1, 0, 0], (n_lin_conns, 1))
+        _fibres = np.vstack([case.vectors.fibres,_dummy_vals_for_lin_connections])
+
+    assert _fibres.shape[0] == n_lines, "Number of .elem lines do not match .lon lines"
+
+    with open(output_path.with_suffix('.lon'), 'w') as f:
+        f.write("1\n")
+        np.savetxt(
+            f,
+            _fibres,
+            fmt="%.6f",
+            comments='',
+        )
 
     # Saving pacing sites if they exist
     if case.fields.pacing_site is None or not export_pacing_site:

--- a/openep/mesh/mesh_routines.py
+++ b/openep/mesh/mesh_routines.py
@@ -100,7 +100,7 @@ def _create_trimesh(pyvista_mesh):
     """
 
     vertices = pyvista_mesh.points
-    faces = pyvista_mesh.faces.reshape(pyvista_mesh.n_faces, 4)[:, 1:]  # ignore to number of vertices per face
+    faces = pyvista_mesh.faces.reshape(pyvista_mesh.n_cells, 4)[:, 1:]  # ignore to number of vertices per face
 
     return trimesh.Trimesh(vertices, faces, process=False)
 

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -145,7 +145,7 @@ def test_no_field(case):
 
 def test_remove_unreferenced_points(dataset_2, dataset_2_mesh):
 
-    expected_indices = dataset_2_mesh.faces.reshape(dataset_2_mesh.n_faces, 4)[:, 1:]
+    expected_indices = dataset_2_mesh.faces.reshape(dataset_2_mesh.n_cells, 4)[:, 1:]
     dataset_2.remove_unreferenced_points()
 
     assert_allclose(dataset_2_mesh.points, dataset_2.points)


### PR DESCRIPTION
- Modified RBF method to use mesh projected pointed instead of bi-egm locations
- Added setting to ignore_interpolation for RBF method of CV calculation
- Added new RBF Legacy method for interpolation (to replicate Ali's code) this method allows epsilon as None
- Fibres lines and streamlines are now visbile using toggles in Display
- Preferences for Fibre lines have been added
- Load for streamline was long, therefore runs on background thread on load (with setting to disable)
- Cleaned up depreciation warnings in logs
- Accept/Reject buttons are fixed to view (no need to scroll).