### PR TITLE
Feature/SM-169: Load custom fields from VTK

### DIFF
--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -99,22 +99,6 @@ class Fields:
             mesh (pyvista.PolyData): mesh from which Fields will be created.
         """
 
-        # List of attributes to keep as cell_data
-        protected = ["cell_region", "transverse_fibres", "longitudinal_fibres"]
-
-        # Backup and remove protected arrays if they exist
-        protected_data = {}
-        for name in protected:
-            if name in mesh.cell_data:
-                protected_data[name] = mesh.cell_data.pop(name)
-
-        # Convert everything else from cell_data → point_data
-        mesh = mesh.cell_data_to_point_data()
-
-        # Restore protected arrays back into cell_data
-        for name, data in protected_data.items():
-            mesh.cell_data[name] = data
-
         fields = cls()
         
         #Load all fieldds from mesh

--- a/openep/data_structures/surface.py
+++ b/openep/data_structures/surface.py
@@ -99,14 +99,28 @@ class Fields:
             mesh (pyvista.PolyData): mesh from which Fields will be created.
         """
 
+        # List of attributes to keep as cell_data
+        protected = ["cell_region", "transverse_fibres", "longitudinal_fibres"]
+
+        # Backup and remove protected arrays if they exist
+        protected_data = {}
+        for name in protected:
+            if name in mesh.cell_data:
+                protected_data[name] = mesh.cell_data.pop(name)
+
+        # Convert everything else from cell_data → point_data
+        mesh = mesh.cell_data_to_point_data()
+
+        # Restore protected arrays back into cell_data
+        for name, data in protected_data.items():
+            mesh.cell_data[name] = data
+
         fields = cls()
+        
+        #Load all fieldds from mesh
         for point_data in mesh.point_data:
-            if point_data not in fields:
-                continue
             fields[point_data] = np.asarray(mesh.point_data[point_data])
         for cell_data in mesh.cell_data:
-            if cell_data not in fields:
-                continue
             fields[cell_data] = np.asarray(mesh.cell_data[cell_data])
 
         return fields


### PR DESCRIPTION
Load all fields (including custom) from VTK. All fields will be per-point apart from protected: cell_regions, transverse_fibres, longitudinal_fibres.