### PR TITLE
Feature/SM-174: Ensure electric data are correct shape on loading

### DIFF
--- a/openep/io/matlab.py
+++ b/openep/io/matlab.py
@@ -233,6 +233,16 @@ def _load_mat_below_v73(filename):
         simplify_cells=True,
     )['userdata']
 
+    # Ensure data are the right shape
+    data['electric']['names'] = np.atleast_1d(data['electric']['names'])
+    data['electric']['include'] = np.atleast_1d(data['electric']['include'])
+    data['electric']['electrodeNames_bip'] = np.atleast_1d(data['electric']['electrodeNames_bip'])
+    data['electric']['egmX'] = np.atleast_2d(data['electric']['egmX']) if data['electric']['egmX'].size!=0 else np.array([])
+    data['electric']['egm'] = np.atleast_1d(data['electric']['egm'])
+    data['electric']['egmGain'] = np.atleast_1d(data['electric']['egmGain'])
+    data['electric']['egmSurfX'] = np.atleast_2d(data['electric']['egmSurfX']) if data['electric']['egmSurfX'].size!=0 else np.array([])
+    data['electric']['barDirection'] = np.atleast_2d(data['electric']['barDirection']) if data['electric']['barDirection'].size!=0 else np.array([])
+
     data['electric']['tags'] = _decode_tags(data['electric']['tags'])
 
     data['electric']['impedances']['time'] = _cast_to_float(data['electric']['impedances']['time'])


### PR DESCRIPTION
Fixed bug where a mesh with only a single landmark saved wouldn't load - this was due to behaviour of `scipy.io.loadmat(simplify_cells=True)` squeezing arrays in unexpected ways. Specific arrays that were causing problems are now forced to be correct dimensions.