### PR TITLE
BUGFIX/EPW-12: Setup changed to read reqs line by line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 import glob
 from setuptools import setup, find_packages
-from pkg_resources import parse_requirements
 
 source_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -11,26 +10,30 @@ with open(os.path.join(source_dir, "openep/_version.py")) as o:
     exec(o.read(), version_info)
 
 # read install requirements from requirements.txt
-with open(os.path.join(source_dir, "requirements.txt")) as o:
-    requirements = [str(r) for r in parse_requirements(o.read())]
+with open(os.path.join(source_dir, "requirements.txt")) as f:
+    requirements = [
+        line.strip()
+        for line in f
+        if line.strip() and not line.startswith("#")
+    ]
 
 setup(
     name="OpenEp",
-    version=version_info['__version__'],
+    version=version_info["__version__"],
     description="Open Source solution for electrophysiology data analysis",
     author="Steven Williams",
     author_email="steven.williams@ed.ac.uk",
     packages=find_packages(),
-    py_modules=[os.path.splitext(os.path.basename(path))[0] for path in glob.glob('openep/*.py')],
+    py_modules=[os.path.splitext(os.path.basename(path))[0] for path in glob.glob("openep/*.py")],
     install_requires=requirements,
-    url='https://github.com/openep/openep-gui',
+    url="https://github.com/openep/openep-gui",
     project_urls={
-        'Documentation': 'https://openep-py.readthedocs.io/en/latest/',
-        'Issue Tracker': 'https://github.com/openep/openep-py/issues',
+        "Documentation": "https://openep-py.readthedocs.io/en/latest/",
+        "Issue Tracker": "https://github.com/openep/openep-py/issues",
     },
-    python_requires='>=3.8',
+    python_requires=">=3.8",
     include_package_data=True,
     package_data={
-        'openep/_datasets/OpenEP-MATLAB': ['_datasets/OpenEP-MATLAB/*.mat']
-    }
+        "openep/_datasets/OpenEP-MATLAB": ["_datasets/OpenEP-MATLAB/*.mat"]
+    },
 )


### PR DESCRIPTION
This PR fixes a broken editable install caused by `setup.py` importing `parse_requirements` from `pkg_resources`. Under newer pip/setuptools build isolation, `pkg_resources` may not be available when pip queries build requirements, causing `pip install -e . `to fail with `ModuleNotFoundError`. 

The fix removes the pkg_resources dependency and reads requirements.txt directly, preserving the existing install requirements while restoring compatibility with modern editable builds.